### PR TITLE
Fix memory leak in HTTP server

### DIFF
--- a/main/httpserver.cpp
+++ b/main/httpserver.cpp
@@ -71,7 +71,9 @@ esp_err_t handlePropertiesList(httpd_req_t *req) {
   }
   httpd_resp_set_type(req, CONTENT_TYPE_JSON);
   set_allow_origin_header(req);
-  httpd_resp_sendstr(req, cJSON_PrintUnformatted(root));
+  char *json = cJSON_PrintUnformatted(root);
+  httpd_resp_sendstr(req, json);
+  cJSON_free(json);
   cJSON_Delete(root);
   return ESP_OK;
 }


### PR DESCRIPTION
## Summary
- stop leaking memory in handlePropertiesList by freeing the generated JSON

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683ff6129c2083248796be6c1925a3c2