### PR TITLE
Fix property function parameter typo

### DIFF
--- a/main/property.cpp
+++ b/main/property.cpp
@@ -12,9 +12,9 @@ std::unordered_map<std::string, Property *> g_properties;
 
 } // namespace
 
-void add(const std::string &key, Property *proeprty) {
+void add(const std::string &key, Property *property) {
   const auto lock = std::lock_guard(g_mutex);
-  g_properties[key] = proeprty;
+  g_properties[key] = property;
 }
 
 void set(const std::string &key, const std::string &value) {

--- a/main/property.h
+++ b/main/property.h
@@ -13,7 +13,7 @@ public:
   virtual ~Property() = default;
 };
 
-void add(const std::string &key, Property *proeprty);
+void add(const std::string &key, Property *property);
 void set(const std::string &key, const std::string &value);
 std::string get(const std::string &key);
 std::vector<std::string> keys();


### PR DESCRIPTION
## Summary
- rename `proeprty` parameter to `property`

## Testing
- `./build.sh` *(fails: `../esp-idf/export.sh: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_683ff7df31a88324b09500b382414d00