### PR TITLE
Fix parseHex include

### DIFF
--- a/main/Color.cpp
+++ b/main/Color.cpp
@@ -1,4 +1,5 @@
 #include "Color.h"
+#include <cstdlib>
 
 namespace ui {
 


### PR DESCRIPTION
## Summary
- include `<cstdlib>` in `Color.cpp`

## Testing
- `g++ -std=c++17 -Wall -Wextra -pedantic -c main/Color.cpp`


------
https://chatgpt.com/codex/tasks/task_e_683ff7e0cce08324a85f8a2954e569bf