### PR TITLE
Replace Wi-Fi banner in clock47_main

### DIFF
--- a/main/clock47_main.cpp
+++ b/main/clock47_main.cpp
@@ -1,11 +1,4 @@
-/* Wi-Fi Provisioning Manager Example
-
-   This example code is in the Public Domain (or CC0 licensed, at your option.)
-
-   Unless required by applicable law or agreed to in writing, this
-   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-   CONDITIONS OF ANY KIND, either express or implied.
-*/
+/* Main entry for the Clock47 application. */
 
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
## Summary
- remove the leftover "Wi-Fi Provisioning Manager Example" banner
- add a short description of the main entry file

## Testing
- `idf.py --version` *(fails: command not found)*
- `make -n` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683ff7e272dc83249f7aa0e84c166b8e